### PR TITLE
fix: login bg image repeat

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -70,7 +70,7 @@ export default function Login() {
   return (
     <>
       <div className="container relative hidden h-screen flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
-        <div className="relative hidden h-full flex-col bg-[url('/home.svg')] bg-auto p-10 text-white dark:border-r lg:flex">
+        <div className="relative hidden h-full flex-col bg-[url('/home.svg')] bg-auto bg-no-repeat bg-center p-10 text-white dark:border-r lg:flex">
           <div className="absolute inset-0 " />
         </div>
         <div className="lg:p-8">


### PR DESCRIPTION
Adjust the centralized login image and not repeat it

before:
![image](https://github.com/Thiago-Mota-Santos/pagarmepix/assets/15316761/dfe0a586-0b87-4225-85c0-b433e2a9b3e6)

after:
![image](https://github.com/Thiago-Mota-Santos/pagarmepix/assets/15316761/eeb265fd-d604-471f-b3c7-aea2eb43d0f8)
